### PR TITLE
Fixint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ kernel.bin: kernel/kernel_entry.o ${OBJ}
 	nasm $< -f elf -o $@
 
 %.bin: %.asm
-	nasm $< -f bin -I ’../../16bit/’ -o $@
+	nasm $< -f bin -I ../../16bit/ -o $@
 
 %.bin: %.asm
-	nasm $< -f bin -I ’../../16bit/’ -o $@
+	nasm $< -f bin -I ../../16bit/ -o $@
 
 clean:
 	rm -fr *.bin *.dis *.o os-image

--- a/boot/bootsect2.asm
+++ b/boot/bootsect2.asm
@@ -4,8 +4,13 @@
 bootld_start:
 	KERNEL_OFFSET equ 0x2000
 
-	mov bp, 0x9000
-	mov sp, bp
+	xor ax, ax      ; Explicitly set ES = DS = 0
+	mov ds, ax
+	mov es, ax
+	mov bx, 0x8C00  ; Set SS:SP to 0x8C00:0x0000 . The stack will exist
+	                ;     between 0x8C00:0x0000 and 0x8C00:0xFFFF
+	mov ss, bx
+	mov sp, ax
 
 	mov [BOOT_DRIVE], dl
 
@@ -36,7 +41,10 @@ disk_load:
 dap:
     db 0x10				; Size of DAP
     db 0
-    dw 120				; Number of sectors to read
+    ; You can only read 46 sectors into memory between 0x2000 and
+    ; 0x7C00. Don't read anymore or we overwrite the bootloader we are
+    ; executing from. (0x7c00-0x2000)/512 = 46
+    dw 46				; Number of sectors to read
     dw KERNEL_OFFSET	; Offset
     dw 0				; Segment
 	dd 1

--- a/boot/bootsect2.asm
+++ b/boot/bootsect2.asm
@@ -148,7 +148,8 @@ pm_setup:
 	    mov gs, ax
 	    mov ss, ax
 
-	    mov ebp, 0x1000
+        ; Place stack below EBDA in lower memory
+	    mov ebp, 0x9c000
 	    mov esp, ebp
 
 	    mov ebx, pmode_msg

--- a/headers/idt.h
+++ b/headers/idt.h
@@ -61,7 +61,7 @@ struct idt_entry_s {
 
 typedef struct idt_entry_s idt_entry;
 
-void fillidt(void* idt, int select, void *offset, int type, int perm) {
+void fillidt(void* idt, int select, void (*offset)(void), int type, int perm) {
   size_t idt_ent_size = (size_t) 8;       // 8 bytes per entry
 
 	uint8_t type_attr;
@@ -86,7 +86,7 @@ static inline void lidt(void* base, uint16_t size) {
         void*    base;
     } __attribute__((packed)) IDTR = {size, base};
 
-    asm ("lidt %0" : : "m"(IDTR));
+    __asm__ ("lidt %0" : : "m"(IDTR));
 }
 
 void init_idt() {
@@ -99,7 +99,7 @@ void init_idt() {
 
 	_PIC_remap(32, 40);													// remap the PIC
 
-	asm ("sti");												// re-enable interrupts
+	__asm__ ("sti");												// re-enable interrupts
 }
 
 #endif

--- a/headers/idt.h
+++ b/headers/idt.h
@@ -6,52 +6,62 @@
 #include "config.h"
 #include "ports.h"
 
-void irq0func();
+#define MAX_ISR_NUM 33   /* 33 is keyboard handler IRQ1 */
+                         /* Set this to the highest ISR you use */
 
-void* irq0handler(void)
+extern void isr_irq0(void);
+extern void isr_irq1(void);
+
+/* Define an ISR stub for IRQ0 */
+__asm__(".global isr_irq0\n"
+        "isr_irq0:\n\t"
+        "cld\n\t"                    /* Set direction flag forward for C functions */
+        "pusha\n\t"                  /* Save all the registers */
+        /* Other stuff here */
+        "call isr_irq0_handler\n\t"
+        "popa\n\t"                   /* Restore all the registers */
+        "iret");
+
+/* Define the IRQ0 timer interrupt handler called by the stub */
+void isr_irq0_handler(void)
 {
-	volatile void* address;
-	asm goto("jmp %l[ISREnd]" ::: "memory" : ISREnd);																	// jump to end of ISR
-	asm volatile(".align 16" ::: "memory");
-	ISRStart:
-	asm volatile(
-		"pushal							\n\t"																												// save regs
-		"pushl %%ebp				\n\t"
-		"movl %%esp, %%ebp	\n\t"
-		"cld										"																												// direction flag is used by gcc
-		::: "memory");
-	asm volatile(
-		"pushl %%es       	\n\t"																												// save segment regs
-		"pushl %%ds       	\n\t"
-		"movw $16, %%cx   	\n\t"																												// set segment regs for kernel
-		"movw %%cx, %%ds  	\n\t"
-		"movw %%cx, %%es  	\n\t"
-		"addl $4, (%%esp) 	\n\t"																												// add 4 to make it point to PUSHAD struct
-		"call *%%eax      	\n\t"																												// call IRQ func.
-		:: "a"(irq0func): "memory");																										// eax is the IRQ 0 function
-	asm volatile(
-		"popl %%es					\n\t"																												// restore everything
-		"popl %%ds					\n\t"
-		"leave							\n\t"
-		"popal							\n\t"
-		"iret										"																												// return from interrupt handler
-		::: "memory");
-	ISREnd:
-	asm goto(
-		".intel_syntax noprefix        \n\t"
-		"mov eax, offset %l[ISRStart]	 \n\t"																						// get address of ISR start
-		"mov [ebx], eax                \n\t"																						// set ebx to adderss
-		".att_syntax                       "
-		:: "b"(&address) : "eax", "memory" : ISRStart);																	// ebx to be set to adderss
-	return (void*) address;																														// return adderss of ISR
+    /* Do timer handling here */
+
+    /* End of interrupt */
+	_PIC_sendEOI(0x0);
+    return;
 }
 
-void irq0func() {
-	// do something
-	_PIC_sendEOI(0);
+/* Define an ISR stub for IRQ1 */
+__asm__(".global isr_irq1\n"
+        "isr_irq1:\n\t"
+        "cld\n\t"                    /* Set direction flag forward for C functions */
+        "pusha\n\t"                  /* Save all the registers */
+        "call isr_irq1_handler\n\t"
+        "popa\n\t"                   /* Restore all the registers */
+        "iret");
+
+/* Define the IRQ1 keyboard interrupt handler called by the stub */
+void isr_irq1_handler(void)
+{
+    /* Do keyboard interrupt handling here */
+
+    /* End of interrupt */
+	_PIC_sendEOI(0x1);
+    return;
 }
 
-void fillidt(void* idt, int select, int offset, int type, int perm) {
+struct idt_entry_s {
+  uint16_t offset_1;                    // offset bits 0..15
+  uint16_t selector;                    // a code segment selector in the GDT or LDT
+  uint8_t zero;                         // unused
+  uint8_t type_attr;                                      // type and attributes
+  uint16_t offset_2;                    // offset bits 16..31
+} __attribute__ ((packed));
+
+typedef struct idt_entry_s idt_entry;
+
+void fillidt(void* idt, int select, void *offset, int type, int perm) {
   size_t idt_ent_size = (size_t) 8;       // 8 bytes per entry
 
 	uint8_t type_attr;
@@ -66,14 +76,8 @@ void fillidt(void* idt, int select, int offset, int type, int perm) {
 	type_attr <<= 4;												// 4 bits to set
 	type_attr |= type;											// type is 4 bits
 
-  struct {
-    uint16_t offset_1;                    // offset bits 0..15
-    uint16_t selector;                    // a code segment selector in the GDT or LDT
-    uint8_t zero;                         // unused
-    uint8_t type_attr;										// type and attributes
-    uint16_t offset_2;                    // offset bits 16..31
-  } __attribute__ ((packed)) idt_desc = {offset & 0xffff, select, 0, type_attr, (offset & 0xffff0000) >> 16};
-  memcpy(&idt_desc, idt, idt_ent_size);		// copy the descriptor
+  idt_entry idt_desc = {((uintptr_t)offset) & 0xffff, select, 0, type_attr, ((uintptr_t)offset & 0xffff0000) >> 16};
+  memcpy(idt, &idt_desc, idt_ent_size);		// copy the descriptor
 }
 
 static inline void lidt(void* base, uint16_t size) {
@@ -86,15 +90,16 @@ static inline void lidt(void* base, uint16_t size) {
 }
 
 void init_idt() {
-  void* idt = (void*) 0x00000;
+    idt_entry *idt = (idt_entry *)0x00000;
 
-	fillidt(idt+(32*8), 8, irq0handler(), 0xe, 0);
+	fillidt(idt+32, 8, isr_irq0, 0xe, 0);
+	fillidt(idt+33, 8, isr_irq1, 0xe, 0);
 
-	lidt(idt, 128);
+	lidt(idt, sizeof(idt_entry)*(MAX_ISR_NUM+1) - 1);
 
 	_PIC_remap(32, 40);													// remap the PIC
 
-	//asm ("sti");												// re-enable interrupts
+	asm ("sti");												// re-enable interrupts
 }
 
 #endif

--- a/headers/keyboard.h
+++ b/headers/keyboard.h
@@ -3,13 +3,13 @@
 
 #define KEY_NUM						700
 
-char scancode[KEY_NUM];
+unsigned char scancode[KEY_NUM];
 char printKey();
 char getChar();
 void getText();
 char getScancode();
 
-char scancode[KEY_NUM] = {
+unsigned char scancode[KEY_NUM] = {
 	0x1b,	// ASCII for escape
 	'1',
 	'2',

--- a/headers/ports.h
+++ b/headers/ports.h
@@ -10,19 +10,19 @@ static inline uint8_t inb(uint16_t port);
 static inline void io_wait(void);
 
 static inline void outb(uint16_t port, uint8_t val) {
-    asm volatile ( "outb %0, %1" : : "a"(val), "Nd"(port) );
+    __asm__ __volatile__ ( "outb %0, %1" : : "a"(val), "Nd"(port) );
 }
 
 static inline uint8_t inb(uint16_t port) {
     uint8_t ret;
-    asm volatile ( "inb %1, %0"
+    __asm__ __volatile__ ( "inb %1, %0"
                    : "=a"(ret)
                    : "Nd"(port) );
     return ret;
 }
 
 static inline void io_wait(void) {
-    asm volatile ( "jmp 1f\n\t"
+    __asm__ __volatile__ ( "jmp 1f\n\t"
                    "1:jmp 2f\n\t"
                    "2:" );
 }

--- a/headers/power.h
+++ b/headers/power.h
@@ -18,7 +18,7 @@ void reboot()
 {
     uint8_t temp;
 
-    asm volatile ("cli");
+    __asm__ __volatile__ ("cli");
 
     do {
         temp = inb(KBRD_INTRFC);						        //empty user data
@@ -28,7 +28,7 @@ void reboot()
 
     outb(KBRD_INTRFC, KBRD_RESET);						      //pulse CPU reset line
 loop:
-    asm volatile ("hlt");
+    __asm__ __volatile__ ("hlt");
     goto loop;
 }
 

--- a/headers/screen.h
+++ b/headers/screen.h
@@ -11,8 +11,8 @@
 
 /* Define colors */
 
-#define WHITE_ON_BLACK			0b00001111
-#define LGREEN_ON_BLACK			0b00001010
+#define WHITE_ON_BLACK			0x0f /* 0b00001111 */
+#define LGREEN_ON_BLACK			0x0a /* 0b00001010 */
 
 #define MAX_ROWS						25
 #define MAX_COLS						80
@@ -143,7 +143,7 @@ void clearScreen(){
 }
 
 void printi(int input, int base) {
-	char* buf;
+	char buf[64];
 	printf(itoa(input, buf, base));
 }
 

--- a/headers/screen.h
+++ b/headers/screen.h
@@ -172,7 +172,7 @@ void scrollDown() {
 	// Copy rows
 
 	for(int row = 0; row <= MAX_ROWS; row++){
-		memcpy(VIDEO_ADDRESS + getOffset(0, row), VIDEO_ADDRESS + getOffset(0, row+1), row_s);
+		memcpy(video_memory + getOffset(0, row), video_memory + getOffset(0, row+1), row_s);
 	}
 
 	//Move cursor back

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -19,7 +19,7 @@ void* commands[5] = {
 	&help,
 	"reboot",
 	&reboot,
-	0x121212			// Command list signiature
+	(void *)0x121212			// Command list signiature
 };
 
 void fallback() {
@@ -65,7 +65,7 @@ void terminal() {
 void parseCommand(char* command) {
 	int i;
 	int success = 0;
-	for(i = 0; commands[i] != 0x121212; i+=2) {
+	for(i = 0; commands[i] != (void *)0x121212; i+=2) {
 		if (strcmp(command, commands[i])) {
 			success = 1;
 			int (*commandPtr)();
@@ -87,7 +87,7 @@ void parseCommand(char* command) {
 void help() {
 	int i;
 	printf("Commands:");
-	for(i = 0; commands[i] != 0x121212; i+=2) {
+	for(i = 0; commands[i] != (void *)0x121212; i+=2) {
 		printf("\n");
 		printf(commands[i]);
 	}

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -14,12 +14,16 @@ void terminal();
 void help();
 void foo();
 
-void* commands[5] = {
-	"help",
-	&help,
-	"reboot",
-	&reboot,
-	(void *)0x121212			// Command list signiature
+struct cmd_entry_t {
+    char *cmd_str;
+    void (*cmd_fun)(void);
+};
+typedef struct cmd_entry_t cmd_entry;
+
+cmd_entry commands[5] = {
+	{"help", &help},
+	{"reboot", &reboot},
+	{(void *)0x121212, NULL}			// Command list signiature
 };
 
 void fallback() {
@@ -54,7 +58,7 @@ void main() {
 void terminal() {
 	while (1) {				//Forever
 		printf("NMOS:>");
-		char* command;
+		char command[256];
 		getText(command);
 		delay(1000000);
 		parseCommand(command);
@@ -65,11 +69,11 @@ void terminal() {
 void parseCommand(char* command) {
 	int i;
 	int success = 0;
-	for(i = 0; commands[i] != (void *)0x121212; i+=2) {
-		if (strcmp(command, commands[i])) {
+	for(i = 0; commands[i].cmd_str != (void *)0x121212; i++) {
+		if (strcmp(command, commands[i].cmd_str)) {
 			success = 1;
-			int (*commandPtr)();
-			commandPtr = commands[i+1];
+			void (*commandPtr)(void);
+			commandPtr = commands[i].cmd_fun;
 			(*commandPtr)();
 		}
 	}
@@ -87,8 +91,8 @@ void parseCommand(char* command) {
 void help() {
 	int i;
 	printf("Commands:");
-	for(i = 0; commands[i] != (void *)0x121212; i+=2) {
+	for(i = 0; commands[i].cmd_str != (void *)0x121212; i++) {
 		printf("\n");
-		printf(commands[i]);
+		printf(commands[i].cmd_str);
 	}
 }


### PR DESCRIPTION
A number of issues:

- You memcpy call in idt.h had source and destination backwards
- The size specified for the idt_desc wasn't enough to include the interrupt handlers  
- Incorrectly indexed a void * with pointer arithmetic in idt.h 
- interrupt handler code you borrowed from OSDev is incomplete and the usage was incorrect in your code. 
- You Read too many sectors with the DAP/Int13&ah=42h and you could possibly overwrite the original bootloader that is still running code. 
- The real mode and protected mode stacks should be placed out of the way somewhere with ample room.

Some fixes:

- I've added a couple of simpler stubs for the interrupts. 
- Added IRQ0 and IRQ1 that can be filled in with your functionality. 
- Moved the real mode and protected mode stacks higher in memory
- Fixed the other bugs mentioned above
- Eliminate the warnings thrown by the compiler.

Note: the keyboard will act erratically until you add appropriate code to the IRQ1 interrupt handler.